### PR TITLE
Reserve the original size of image

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -85,15 +85,11 @@ export class D2Processor {
     const svg = parser.parseFromString(image, "image/svg+xml");
     const containerEl = el.createDiv();
 
-    containerEl.style.maxHeight = `${this.plugin.settings.containerHeight}px`;
-    containerEl.style.height = "100vh";
-    containerEl.style.width = "100%";
-    containerEl.style.position = "relative";
-
-    const svgEl = svg.documentElement;
-    svgEl.style.position = "absolute";
-    svgEl.style.width = "100%";
-    svgEl.style.height = "100%";
+    const svgEl = svg.firstElementChild.firstElementChild;
+    svgEl.style.maxHeight = `${this.plugin.settings.containerHeight}px`;
+    svgEl.style.maxWidth = "100%";
+    svgEl.style.height = "fit-content";
+    svgEl.style.width = "fit-content";
 
     containerEl.innerHTML = this.sanitizeSVGIDs(svgEl, ctx.docId);
   }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -85,7 +85,7 @@ export class D2Processor {
     const svg = parser.parseFromString(image, "image/svg+xml");
     const containerEl = el.createDiv();
 
-    const svgEl = svg!.firstElementChild!.firstElementChild;
+    const svgEl = svg!.firstElementChild!.firstElementChild as HTMLElement;
     svgEl.style.maxHeight = `${this.plugin.settings.containerHeight}px`;
     svgEl.style.maxWidth = "100%";
     svgEl.style.height = "fit-content";

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -85,7 +85,7 @@ export class D2Processor {
     const svg = parser.parseFromString(image, "image/svg+xml");
     const containerEl = el.createDiv();
 
-    const svgEl = svg.firstElementChild.firstElementChild;
+    const svgEl = svg!.firstElementChild!.firstElementChild;
     svgEl.style.maxHeight = `${this.plugin.settings.containerHeight}px`;
     svgEl.style.maxWidth = "100%";
     svgEl.style.height = "fit-content";

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -85,7 +85,7 @@ export class D2Processor {
     const svg = parser.parseFromString(image, "image/svg+xml");
     const containerEl = el.createDiv();
 
-    const svgEl = svg!.firstElementChild!.firstElementChild as HTMLElement;
+    const svgEl = svg.documentElement;
     svgEl.style.maxHeight = `${this.plugin.settings.containerHeight}px`;
     svgEl.style.maxWidth = "100%";
     svgEl.style.height = "fit-content";
@@ -190,6 +190,7 @@ export class D2Processor {
       `--pad=${this.plugin.settings.pad}`,
       `--sketch=${this.plugin.settings.sketch}`,
       "--bundle=false",
+      "--scale=1",
     ];
     const cmd = args.join(" ");
     const child = exec(cmd, options);


### PR DESCRIPTION
Images are always scaled to max height even when they are small. It seems that the outer `<svg>` tag d2 generated caused the image to be too large.

Before:

![before](https://github.com/terrastruct/d2-obsidian/assets/37697612/d154f8f3-b0b9-445e-98e2-e419e45db970)

This PR:

![after](https://github.com/terrastruct/d2-obsidian/assets/37697612/b0bd92ff-22ed-4ce9-9d1e-5e1973e6e850)
