### PR TITLE
added basic panzoom functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "child_process": "^1.0.2",
-    "lodash.debounce": "^4.0.8"
+    "lodash.debounce": "^4.0.8",
+    "panzoom": "^9.4.3"
   }
 }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -3,7 +3,7 @@ import { exec, execSync } from "child_process";
 import { delimiter } from "path";
 import debounce from "lodash.debounce";
 import os from "os";
-import panzoom from 'panzoom';
+import panzoom from "panzoom";
 
 import D2Plugin from "./main";
 
@@ -128,7 +128,7 @@ export class D2Processor {
       beforeWheel: (e) => {
         return !e.ctrlKey;
       },
-    })
+    });
   }
 
   export = async (

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -3,8 +3,12 @@ import { exec, execSync } from "child_process";
 import { delimiter } from "path";
 import debounce from "lodash.debounce";
 import os from "os";
+import panzoom from 'panzoom';
 
 import D2Plugin from "./main";
+
+const MIN_ZOOM = 0.1;
+const MAX_ZOOM = 15;
 
 export class D2Processor {
   plugin: D2Plugin;
@@ -118,6 +122,13 @@ export class D2Processor {
 
     this.formatLinks(svgEl);
     containerEl.innerHTML = this.sanitizeSVGIDs(svgEl, ctx.docId);
+    panzoom(containerEl, {
+      maxZoom: MAX_ZOOM,
+      minZoom: MIN_ZOOM,
+      beforeWheel: (e) => {
+        return !e.ctrlKey;
+      },
+    })
   }
 
   export = async (


### PR DESCRIPTION
Added very basic panzooming support, works like d2-playground website. It's not perfect, but it works.

Related issue: #33 

Known issues:
- Everytime recompile button was hit, diagram will back to its original size and position
- Diagram will be gone if you swipe too hard, but it can be reset with recompile button

Nice to add:
- Reset button (size and position)
- Zoom slider

![image](https://github.com/terrastruct/d2-obsidian/assets/21243980/9669010c-0e81-468e-b2e1-51a3bb4c18a0)
