### PR TITLE
Update cache action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/yarn/v6
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/yarn/v6
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
## Summary

- update `actions/cache` from v2 to v4 in CI and daily workflows
- restore jobs that GitHub now rejects before checkout

## Validation

- YAML parse
- actionlint (excluding existing old-action-version warnings unrelated to this change)
- `git diff --check`